### PR TITLE
Remove 'ghc' from build-depends.

### DIFF
--- a/silently.cabal
+++ b/silently.cabal
@@ -1,5 +1,5 @@
 name: silently
-version: 1.1.4
+version: 1.1.5
 cabal-version: >= 1.2
 build-type: Simple
 license: BSD3
@@ -21,7 +21,7 @@ extra-source-files:
   src/other/System/IO/Silently.hs
 
 Library
-  build-depends: base >=4 && <=5, directory -any, ghc -any
+  build-depends: base >=4 && <=5, directory -any
   exposed-modules: System.IO.Silently
   exposed: True
   buildable: True


### PR DESCRIPTION
This packages doesn't import any modules from the 'ghc' package. It does
import 'GHC.IO.Handle', but that is provided by the 'base' package.
