### PR TITLE
preserve handle buffering

### DIFF
--- a/silently.cabal
+++ b/silently.cabal
@@ -56,6 +56,7 @@ test-suite spec-specific
     , silently
     , directory
     , nanospec
+    , temporary
 
 -- This tests the generic implementation, that should work on all platforms.
 test-suite spec-generic
@@ -76,3 +77,4 @@ test-suite spec-generic
     , deepseq
     , directory
     , nanospec
+    , temporary

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,8 +4,10 @@ import           Test.Hspec
 import           System.IO
 import           System.IO.Silently
 import           System.Directory
+import           System.IO.Temp
 
 import           Control.Exception
+import           Control.Monad
 
 main :: IO ()
 main = hspec spec
@@ -26,3 +28,11 @@ spec = do
   describe "capture" $ do
     it "captures stdout" $ do
       capture (putStr "foo" >> return 23) `shouldReturn` ("foo", 23 :: Int)
+
+  describe "hCapture" $ do
+    forM_ [NoBuffering, LineBuffering, BlockBuffering Nothing] $ \buffering -> do
+      it ("preserves " ++ show buffering) $ do
+        withSystemTempFile "silently" $ \_file h -> do
+          hSetBuffering h buffering
+          _ <- hCapture [h] (return ())
+          hGetBuffering h `shouldReturn` buffering


### PR DESCRIPTION
@trystan: I've worked on this PR with @sol. He can release this to hackage if you want.

We could also maintain `silently` under the `hspec` organization if you want.
